### PR TITLE
Add total when the stream ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module works with the following Elasticsearch nodejs clients:
 
 `ElasticsearchScrollStream` is a Readable Stream, so it supports all the methods of a classic `Stream#Readable`.
 In addition it exposes a `#close()` method to force the stream to stop sourcing from Elasticsearch.
+When the stream is done, it will contain an attribute `_total` that is the total number of matching documents, which can be useful if you forced the stream to stop.
 
 
 ## Installing

--- a/lib/elasticsearch-stream.js
+++ b/lib/elasticsearch-stream.js
@@ -26,6 +26,7 @@ var LibElasticasearchScrollStream = function(client, query_opts, optional_fields
   this._options.scroll = query_opts.scroll || '10m';
   this._reading = false;
   this._counter = 0;
+  this._total = 0;
   this._forceClose = false;
   Readable.call(this, stream_opts);
 };
@@ -57,7 +58,7 @@ LibElasticasearchScrollStream.prototype._read = function() {
       // populate extra fields
       self._extrafields.forEach(function(entry) {
         ref_results[entry] = hit[entry];
-      })
+      });
 
       self.push(objectMode ? ref_results : JSON.stringify(ref_results));
       self._counter++;
@@ -72,6 +73,7 @@ LibElasticasearchScrollStream.prototype._read = function() {
       return setImmediate(function() {
         self._reading = false;
         self._counter = 0;
+        self._total = response.hits.total;
         self._forceClose = false;
         self.push(null);
       });


### PR DESCRIPTION
For interrupted streams, I'd love to be able to get the total, so I added at the end.

This seems fairly simple and the code already relies on this so I don't know if you want additional tests for it ?