### PR TITLE
Support _source:false

### DIFF
--- a/lib/elasticsearch-stream.js
+++ b/lib/elasticsearch-stream.js
@@ -41,7 +41,7 @@ class LibElasticsearchScrollStream extends Readable {
     this._total = typeof body.hits.total === 'object' ? body.hits.total.value : body.hits.total
 
     body.hits.hits.forEach(hit => {
-      let ref_results = hit.fields ? hit.fields : hit._source || hit
+      let ref_results = hit.fields ? hit.fields : hit._source || {}
 
       // populate extra fields
       this._extrafields.forEach(entry => {

--- a/lib/elasticsearch-stream.js
+++ b/lib/elasticsearch-stream.js
@@ -41,7 +41,7 @@ class LibElasticsearchScrollStream extends Readable {
     this._total = typeof body.hits.total === 'object' ? body.hits.total.value : body.hits.total
 
     body.hits.hits.forEach(hit => {
-      let ref_results = hit.fields ? hit.fields : hit._source
+      let ref_results = hit.fields ? hit.fields : hit._source || hit
 
       // populate extra fields
       this._extrafields.forEach(entry => {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -203,27 +203,31 @@ describe('elasticsearch_scroll_stream', function () {
     let current_doc
     let elasticsearch_client = new Client({ node: 'http://localhost:9200' })
 
-    let es_stream = new ElasticsearchScrollStream(elasticsearch_client, {
-      index: 'elasticsearch-test-scroll-stream',
-      type: 'test-type',
-      scroll: '10s',
-      size: '50',
-      _source: false,
-      body: {
-        query: {
-          bool: {
-            must: [
-              {
-                query_string: {
-                  default_field: '_all',
-                  query: 'name:third*',
+    let es_stream = new ElasticsearchScrollStream(
+      elasticsearch_client,
+      {
+        index: 'elasticsearch-test-scroll-stream',
+        type: 'test-type',
+        scroll: '10s',
+        size: '50',
+        _source: false,
+        body: {
+          query: {
+            bool: {
+              must: [
+                {
+                  query_string: {
+                    default_field: '_all',
+                    query: 'name:third*',
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
         },
       },
-    })
+      ['_id']
+    )
 
     es_stream.on('data', function (data) {
       expect(es_stream._total).to.equal(20)


### PR DESCRIPTION
Firstly thanks for this great module and your continued work on it.

We have a query, that for performance reasons we want to set `_source: false`.
Just now `elasticsearch-scroll-stream` assumes there is always a `_source` but with a simple change it is possible to forward the results even when no `_source` exists.

If you would prefer, I could alter this to only forward those extra params specified in the "extra fields" third param, initially setting the `ref_results` to an empty object.

Please let me know what you would prefer.

Thanks again.